### PR TITLE
Use more focused lodash.isequal package for deep comparisons.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "escodegen": "^1.7.0",
     "esprima-ast-utils": "0.0.6",
     "express": "^4.13.3",
-    "ramda": "^0.18.0"
+    "lodash.isequal": "^3.0.4"
   },
   "devDependencies": {
     "bower": "^1.6.5",

--- a/tests/endToEndTests/endToEndTestsSecondMilestone.js
+++ b/tests/endToEndTests/endToEndTestsSecondMilestone.js
@@ -390,7 +390,7 @@ describe('End to End: Second Milestone', function() {
                         sum += i
                     }`;
       output = ``;
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     it('should handle for-in loops that iterate over items in a dictionary', function () {

--- a/tests/parserTests/parserTestsFirstMilestone.js
+++ b/tests/parserTests/parserTestsFirstMilestone.js
@@ -1,7 +1,7 @@
 var makeParser = require('../../transpiler/parser/parser');
 var expect = require('chai').expect;
 var util = require('util');
-var R = require('ramda');
+var isEqual = require('lodash.isequal');
 var parser;
 
 describe('Parser: First Milestone', function() {
@@ -45,7 +45,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = 1; a = 2'
@@ -90,7 +90,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var my_var = 5'
@@ -126,7 +126,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var myVar = 5;`;
@@ -163,7 +163,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var myVar                   =                       5          ;`;
@@ -200,7 +200,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var b = "hello"'
@@ -236,7 +236,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var c = true'
@@ -272,7 +272,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var d = "Test this"'
@@ -308,7 +308,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var name: String = "Joe"; var age: Int = 45;`;
@@ -373,7 +373,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var name: String; var age: Int;`;
@@ -425,7 +425,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var firstBase, secondBase, thirdBase: String`;
@@ -478,7 +478,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`/* Comment 1 */ var a = 1 // Comment 2`;
@@ -519,7 +519,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -558,7 +558,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var empty = [:]'
@@ -596,7 +596,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var empty = [String]();'
@@ -637,7 +637,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var empty = [String:UInt16]();'
@@ -680,7 +680,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var e = ["Eggs", "Milk", "Bacon"]'
@@ -737,7 +737,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var e = [  "Eggs","Milk",           "Bacon"                ] ;'
@@ -795,7 +795,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var f = ["one": 1, "two": 2, "three": 3]'
@@ -896,7 +896,7 @@ describe('Parser: First Milestone', function() {
         ]
         // "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw `var arr = [2,2,3,4,5]; arr[0] = 1`;
@@ -999,7 +999,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var arr = [Int](); arr += [1,2,3];`;
@@ -1086,7 +1086,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var error = (404, "not found")'
@@ -2335,7 +2335,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
 
@@ -3578,7 +3578,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var errorTuple = (404, "not found")
@@ -4913,7 +4913,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var empty = ()';
@@ -4950,7 +4950,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
     // Swift input: 'let g = [1 : "one",2   :"two", 3: "three"]'
     it('should handle erratic spacing', function () {
@@ -5048,7 +5048,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var d = [1, 2]; var one = d[0];`;
@@ -5133,7 +5133,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var d = ["one": 1, "two": 2]; var one = d["one"];`;
@@ -5247,7 +5247,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -5286,7 +5286,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`let justOverOneMillion = 1_000_000.000_000_1`;
@@ -5323,7 +5323,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'let i = 5+6'
@@ -5370,7 +5370,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var j = 5 + 6 / 4 - (-16 % 4.2) * 55'
@@ -5469,7 +5469,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`let l = 6 != 9`;
@@ -5518,7 +5518,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // 'var l = 6 != 7 || (6 == 7 || (6 > 7 || (6 < 7 || (6 >= 7 || 6 <= 7))));'
@@ -5624,7 +5624,7 @@ describe('Parser: First Milestone', function() {
                                 operator: '<=',
                                 left: { value: 6, type: 'Literal', raw: '6' },
                                 right: { value: 7, type: 'Literal', raw: '7' } } } } } } } } ] } ] };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // AST Explorer input: 'var diceRoll = 6; diceRoll == 7;'
@@ -5682,7 +5682,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // AST Explorer input: 'var diceRoll = 6; ++diceRoll == 7;'
@@ -5747,7 +5747,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // AST Explorer input: 'var diceRoll = 6; diceRoll++ == 7;'
@@ -5812,7 +5812,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = 1; var m = ++a; var n = --m;'
@@ -5907,7 +5907,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = 1; var m = a++; var n = m--;'
@@ -6002,7 +6002,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = true; var b = !a; var c = -a; var d = +b'
@@ -6122,7 +6122,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var x = 5; x += 4; x -= 3; x *= 2; x /= 1; x %= 2;`;
@@ -6264,7 +6264,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var a = !true && true || true`;
@@ -6330,7 +6330,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = (6 == 7) ? 1 : -1'
@@ -6403,7 +6403,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var g = 6 == 7 ? true : false;'
@@ -6469,7 +6469,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'let h = false; let i = h ? 1 : 2;'
@@ -6545,7 +6545,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -6617,7 +6617,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var planet = "Earth"; let o = "\(planet)"'
@@ -6699,7 +6699,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var planet = "Earth"; let o = "Hello \(planet)!"'
@@ -6781,7 +6781,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var p = "\(100 - 99), 2, 3"'
@@ -6852,7 +6852,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`let a = 3; let b = 5; let sum = "the sum of a and b is \(a + b).";`;
@@ -6967,7 +6967,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -7092,7 +7092,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var arr = [1, 2]; var s = arr[0];'
@@ -7179,7 +7179,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'let arr = [1, 2]; let t = 100; var u = arr[t - 99];'
@@ -7298,7 +7298,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'let arr = [1,2]; var u = [arr[0]];'
@@ -7392,7 +7392,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'let firstNum = 1; let secNum = 2; var dict = [firstNum: [[1,2], [3,4]], secNum: [["one", "two"], ["three", "four"]]];'
@@ -7622,7 +7622,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'let arr = [1,2]; var v = [arr[0]: [[1,2], [3,4]], arr[1]: [["one", "two"], ["three", "four"]]];'
@@ -7860,7 +7860,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw `var firstNum = 1
@@ -7935,7 +7935,7 @@ describe('Parser: First Milestone', function() {
        { type: "TERMINATOR",                    value: "EOF" }
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Test 21 - Swift input: 'var w = [1: [[1: "two"], [3: "four"]], 2: [["one": 2], ["three": 4]]];'
@@ -8127,7 +8127,7 @@ describe('Parser: First Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 });

--- a/tests/parserTests/parserTestsFourthMilestone.js
+++ b/tests/parserTests/parserTestsFourthMilestone.js
@@ -1,7 +1,7 @@
 var makeParser = require('../../transpiler/parser/parser');
 var expect = require('chai').expect;
 var util = require('util');
-var R = require('ramda');
+var isEqual = require('lodash.isequal');
 var parser;
 
 describe('Parser: Fourth Milestone', function() {
@@ -65,7 +65,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class VideoMode {
@@ -142,7 +142,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class VideoMode {
@@ -240,7 +240,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`struct Resolution {
@@ -290,7 +290,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var resolutionHeight = 480
@@ -359,7 +359,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`struct Greeting {
@@ -376,7 +376,7 @@ describe('Parser: Fourth Milestone', function() {
 
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`struct FixedLengthRange {
@@ -425,7 +425,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class Medley {
@@ -571,7 +571,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class Counter {
@@ -672,7 +672,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class Counter {
@@ -789,7 +789,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class Counter {
@@ -896,7 +896,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`struct Counter {
@@ -982,7 +982,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`struct Counter {
@@ -1033,7 +1033,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class ParentClass {
@@ -1107,7 +1107,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class SuperClass {
@@ -1217,7 +1217,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`class SuperClass {
@@ -1339,7 +1339,7 @@ describe('Parser: Fourth Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`       class    SuperClass            {    var a = 0
@@ -1490,7 +1490,7 @@ describe('Parser: Fourth Milestone', function() {
          { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -1815,7 +1815,7 @@ describe('Parser: Fourth Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw `var one = 1
@@ -2081,7 +2081,7 @@ describe('Parser: Fourth Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw `var negOne = -1
@@ -2171,7 +2171,7 @@ describe('Parser: Fourth Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     xdescribe('Range Operations', function () {
@@ -2189,7 +2189,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.0...5.0'
@@ -2205,7 +2205,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.2...5.3'
@@ -2221,7 +2221,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var b = 1..<5'
@@ -2238,7 +2238,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.0..<5.0'
@@ -2255,7 +2255,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.2..<5.3'
@@ -2272,7 +2272,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1...5; var b = 2..<6'
@@ -2296,7 +2296,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'let start = 0; let end = 10; let range = start..<end; let fullRange = start...end;'
@@ -2331,7 +2331,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",                 value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -2456,7 +2456,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var s = "my string, 123!"
@@ -2532,7 +2532,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var s: String = ""
@@ -2604,7 +2604,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
 
@@ -2722,7 +2722,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var s = "my string, 123!"
@@ -3126,7 +3126,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var greeting = "World"
@@ -3222,7 +3222,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",                 value: "EOF"},
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var famousAuthor = "F. Scott Fitzgerald"
@@ -3405,7 +3405,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var s = "String"
@@ -3496,7 +3496,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -3587,7 +3587,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var arr = [1,2]
@@ -3662,7 +3662,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var arr = [Int]()
@@ -3687,7 +3687,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",                 value: "EOF"},
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var arrOfThreeZeros = [Int](count: 3, repeatedValue: 0)`;
@@ -3763,7 +3763,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var arr = [1,2,4,8,5,7]
@@ -4223,7 +4223,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var arr = [1,2,3,4,5,6,7]
@@ -4282,7 +4282,7 @@ describe('Parser: Fourth Milestone', function() {
           { type: "TERMINATOR",                 value: "EOF"},
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var d = ["array1": [1,2,3], "array2": [4,5,6]]
@@ -4444,7 +4444,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var d = ["array1": [1,2,3], "array2": [4,5,6]]
@@ -4612,7 +4612,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw `var d = ["array1": [1,2,3], "array2": [4,5,6]]
@@ -4765,7 +4765,7 @@ describe('Parser: Fourth Milestone', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
   });

--- a/tests/parserTests/parserTestsSecondMilestone.js
+++ b/tests/parserTests/parserTestsSecondMilestone.js
@@ -1,7 +1,7 @@
 var makeParser = require('../../transpiler/parser/parser');
 var expect = require('chai').expect;
 var util = require('util');
-var R = require('ramda');
+var isEqual = require('lodash.isequal');
 var parser;
 
 describe('Parser: Second Milestone', function() {
@@ -86,7 +86,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var b = 6; if (5 <= 6) {b++};'
@@ -174,7 +174,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var c = 1; if (c == 1) {c *= 5};'
@@ -266,7 +266,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var d = 1; if d != 2 {d++};'
@@ -352,7 +352,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var e = 1; if (e + 1) == 2 {e = 5};'
@@ -455,7 +455,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var f = true; if !f {f = true} else {f = false};'
@@ -565,7 +565,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = 1; if (1 > 2) {++a} else if (1 < 2) {--a} else {a = 42}'
@@ -720,7 +720,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var a = 1; if 1 > 2 {++a} else if 1 < 2 {--a} else {a = 42}'
@@ -872,7 +872,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -957,7 +957,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var i = 10; while i >= 0 {i--}'
@@ -1038,7 +1038,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var i = 10; repeat {i--} while (i >= 0)'
@@ -1122,7 +1122,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var i = 10; repeat {i--} while i >= 0'
@@ -1204,7 +1204,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -1328,7 +1328,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var b = 0; for var j = 0; j < 10; j++ {b++};'
@@ -1448,7 +1448,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -1606,7 +1606,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // Swift input: 'var c = 0; var numbers = [1,2,3,4,5]; for n in numbers {c += n};'
@@ -1758,7 +1758,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -1823,7 +1823,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var e = ["Eggs", "Milk", "Bacon"]
@@ -2054,7 +2054,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     })
 
     // input = String.raw`var name: String = "Joe"
@@ -2206,7 +2206,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`// function body goes here
@@ -2231,7 +2231,7 @@ describe('Parser: Second Milestone', function() {
         "body": [],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`/*
@@ -2256,7 +2256,7 @@ describe('Parser: Second Milestone', function() {
         "body": [],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -2361,7 +2361,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var diceRoll = 6;
@@ -2464,7 +2464,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var x = true
@@ -2767,7 +2767,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -2896,7 +2896,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var arrays = [[1,2,3], [4,5,6], [7,8,9]]
@@ -3219,7 +3219,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -3381,7 +3381,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var sum = 0
@@ -3417,7 +3417,7 @@ describe('Parser: Second Milestone', function() {
         { type: "TERMINATOR",                     value: "EOF"},
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`let interestingNumbers = [
@@ -3839,7 +3839,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -3933,7 +3933,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var i = 10;
@@ -4021,7 +4021,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var i = 10;
@@ -4115,7 +4115,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`var i = 10
@@ -4205,7 +4205,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -4619,7 +4619,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -5089,7 +5089,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`
@@ -5599,7 +5599,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 
@@ -5646,7 +5646,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       }
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     it('should convert print to console.log with multiple parentheses', function() {
@@ -5714,7 +5714,7 @@ describe('Parser: Second Milestone', function() {
         "sourceType": "module"
 
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
 
@@ -6062,7 +6062,7 @@ describe('Parser: Second Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 });

--- a/tests/parserTests/parserTestsThirdMilestone.js
+++ b/tests/parserTests/parserTestsThirdMilestone.js
@@ -1,7 +1,7 @@
 var makeParser = require('../../transpiler/parser/parser');
 var expect = require('chai').expect;
 var util = require('util');
-var R = require('ramda');
+var isEqual = require('lodash.isequal');
 var parser;
 
 describe('Parser: Third Milestone', function() {
@@ -134,7 +134,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func someFunction(a: Int)->Int{
@@ -256,7 +256,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func someFunction (a: Int) -> Int {
@@ -379,7 +379,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func someFunction(a: Int) -> Int {
@@ -502,7 +502,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func someFunction(a: Int)-> Int {
@@ -625,7 +625,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func  someFunction(a: Int)           ->  Int{
@@ -748,7 +748,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sayHelloWorld() -> String {
@@ -805,7 +805,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sayHello(personName: String) -> String {
@@ -930,7 +930,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sayHello(alreadyGreeted: Bool) -> String {
@@ -1090,7 +1090,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sayHello(firstName: String, lastName: String) -> String {
@@ -1254,7 +1254,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func greet(name: String, day: String) -> String {
@@ -1403,7 +1403,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func addSevenInts(first: Int, second: Int, third: Int, fourth: Int, fifth: Int, sixth: Int, seventh: Int) -> Int {
@@ -1682,7 +1682,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func printAllTypes(first: Character, second: Double, third: Float, fourth: Bool, fifth: Int, sixth: Int8, seventh: Int16, eigth: Int32, nineth: Int64, tenth: String, eleventh: UInt, twelvth: UInt8, thirteenth: UInt16, fourteenth: UInt32, fifteenth: UInt64) {
@@ -2512,7 +2512,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func addOne(input: Int) -> Int {
@@ -2669,7 +2669,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func returnTuple(num: Int) -> (plusFive: Int, timesFive: Int) {
@@ -2739,7 +2739,7 @@ describe('Parser: Third Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func nameAndAge(name: String, age: Int) -> (name: String, age: Int) {
@@ -2800,7 +2800,7 @@ describe('Parser: Third Milestone', function() {
         { type: "TERMINATOR",                 value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func minMax(array: [Int]) -> (min: Int, max: Int) {
@@ -2919,7 +2919,7 @@ describe('Parser: Third Milestone', function() {
         { type: "TERMINATOR",                   value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func minMax(array: [Int]) -> (min: Int, max: Int) {
@@ -3038,7 +3038,7 @@ describe('Parser: Third Milestone', function() {
         { type: "TERMINATOR",           value: "EOF"}
       ];
       output = "FILL_ME_IN";
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sumOf(numbers: Int...) -> Int {
@@ -3306,7 +3306,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sumOf(start: Int=0, numbers: Int...) -> Int {
@@ -3724,7 +3724,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func makeIncrementer() -> ((Int) -> Int) {
@@ -3916,7 +3916,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func makeIncrementer() -> ((Int) -> Int) {
@@ -4043,7 +4043,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func makeIncrementer() -> (Int) -> Int {
@@ -4169,7 +4169,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func any(list: [Int], condition: ((Int) -> Bool)) -> Bool {
@@ -4344,7 +4344,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func a(l: [Int], c: ((Int,String,Bool) -> Bool)) -> (Bool) {
@@ -4538,7 +4538,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func any(list: [Int], condition: (Int) -> Bool) -> Bool {
@@ -4711,7 +4711,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func any(list: [Int], condition: ((Int) -> Bool)) -> (Bool) {
@@ -4887,7 +4887,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sayHelloNoOutput(to person: String, from anotherPerson: String) {
@@ -5061,7 +5061,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func sayHello(to person: String, from anotherPerson: String) -> String {
@@ -5235,7 +5235,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func dictionary() -> [String: Int] {
@@ -5402,7 +5402,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func array() -> [Int] {
@@ -5497,7 +5497,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func abc(a: [String: Int]) {
@@ -5653,7 +5653,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func any(list: [Int], condition: ((Int,String,Bool) -> Bool)) -> Bool {
@@ -5844,7 +5844,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func any(list: [Int], condition: (Int) -> Bool) -> (Bool) {
@@ -6018,7 +6018,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw `func addOne(input: Int) -> Int {
@@ -6156,7 +6156,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func returnWorld() -> Int {
@@ -6336,7 +6336,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
 
     // input = String.raw`func returnWorld() -> String {
@@ -6517,7 +6517,7 @@ describe('Parser: Third Milestone', function() {
         ],
         "sourceType": "module"
       };
-      expect(R.equals(parser(input), output)).to.equal(true);
+      expect(isEqual(parser(input), output)).to.equal(true);
     });
   });
 });

--- a/transpiler/parser/test/parserTests.js
+++ b/transpiler/parser/test/parserTests.js
@@ -1,7 +1,7 @@
 var make_parser = require('../parser');
 var expect = require('chai').expect;
 var util = require('util');
-var R = require('ramda');
+var isEqual = require('lodash.isequal');
 var parser;
 
 describe('Parser', function() {
@@ -44,7 +44,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1; a = 2'
@@ -100,7 +100,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var my_var = 5'
@@ -136,7 +136,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var b = "hello"'
@@ -172,7 +172,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 3 - Swift input: 'var c = true'
@@ -208,7 +208,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 4 - Swift input: 'var d = "Test this"'
@@ -244,7 +244,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -283,7 +283,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var empty = [:]'
@@ -321,7 +321,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var empty = [String]();'
@@ -362,7 +362,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var empty = [String:UInt16]();'
@@ -405,7 +405,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var e = ["Eggs", "Milk", "Bacon"]'
@@ -462,7 +462,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var e = [  "Eggs","Milk",           "Bacon"                ] ;'
@@ -520,7 +520,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var f = ["one": 1, "two": 2, "three": 3]'
@@ -621,7 +621,7 @@ describe('Parser', function() {
           ]
           // "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var error = (404, "not found")'
@@ -696,7 +696,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
 
@@ -776,7 +776,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var empty = ()';
@@ -813,7 +813,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'let g = [1 : "one",2   :"two", 3: "three"]'
@@ -912,7 +912,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -951,7 +951,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'let i = 5+6'
@@ -998,7 +998,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var j = 5 + 6 / 4 - (-16 % 4.2) * 55'
@@ -1097,7 +1097,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // 'var l = 6 != 7 || (6 == 7 || (6 > 7 || (6 < 7 || (6 >= 7 || 6 <= 7))));'
@@ -1203,7 +1203,7 @@ describe('Parser', function() {
                               operator: '<=',
                               left: { value: 6, type: 'Literal', raw: '6' },
                               right: { value: 7, type: 'Literal', raw: '7' } } } } } } } } ] } ] };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1; var m = ++a; var n = --m;'
@@ -1298,7 +1298,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1; var m = a++; var n = m--;'
@@ -1393,7 +1393,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = true; var b = !a; var c = -a; var d = +b'
@@ -1513,7 +1513,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = (6 == 7) ? 1 : -1'
@@ -1586,7 +1586,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var g = 6 == 7 ? true : false;'
@@ -1652,7 +1652,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'let h = false; let i = h ? 1 : 2;'
@@ -1728,7 +1728,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1...5'
@@ -1744,7 +1744,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.0...5.0'
@@ -1760,7 +1760,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
         });
 
       // Swift input: 'var a = 1.2...5.3'
@@ -1776,7 +1776,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var b = 1..<5'
@@ -1792,7 +1792,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.0..<5.0'
@@ -1808,7 +1808,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1.2..<5.3'
@@ -1824,7 +1824,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1...5; var b = 2..<6'
@@ -1847,7 +1847,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -1919,7 +1919,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var planet = "Earth"; let o = "\(planet)"'
@@ -2001,7 +2001,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 15 - Swift input: 'var planet = "Earth"; let o = "Hello \(planet)!"'
@@ -2083,7 +2083,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 16 - Swift input: 'var p = "\(100 - 99), 2, 3"'
@@ -2154,7 +2154,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -2278,7 +2278,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 18 - Swift input: 'var arr = [1, 2]; var s = arr[0];'
@@ -2365,7 +2365,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 19 - Swift input: 'let arr = [1, 2]; let t = 100; var u = arr[t - 99];'
@@ -2483,7 +2483,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'let arr = [1,2]; var u = [arr[0]];'
@@ -2577,7 +2577,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
 
@@ -2815,7 +2815,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Test 21 - Swift input: 'var w = [1: [[1: "two"], [3: "four"]], 2: [["one": 2], ["three": 4]]];'
@@ -3007,7 +3007,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
   });
@@ -3089,7 +3089,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var b = 6; if (5 <= 6) {b++};'
@@ -3177,7 +3177,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var c = 1; if (c == 1) {c *= 5};'
@@ -3269,7 +3269,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var d = 1; if d != 2 {d++};'
@@ -3355,7 +3355,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var e = 1; if (e + 1) == 2 {e = 5};'
@@ -3458,7 +3458,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var f = true; if !f {f = true} else {f = false};'
@@ -3568,7 +3568,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1; if (1 > 2) {++a} else if (1 < 2) {--a} else {a = 42}'
@@ -3723,7 +3723,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var a = 1; if 1 > 2 {++a} else if 1 < 2 {--a} else {a = 42}'
@@ -3875,7 +3875,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -3960,7 +3960,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var i = 10; while i >= 0 {i--}'
@@ -4041,7 +4041,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var i = 10; repeat {i--} while (i >= 0)'
@@ -4125,7 +4125,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var i = 10; repeat {i--} while i >= 0'
@@ -4207,7 +4207,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -4331,7 +4331,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var b = 0; for var j = 0; j < 10; j++ {b++};'
@@ -4451,7 +4451,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
 
@@ -4607,7 +4607,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // Swift input: 'var c = 0; var numbers = [1,2,3,4,5]; for n in numbers {c += n};'
@@ -4759,7 +4759,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -4842,7 +4842,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var e = ["Eggs", "Milk", "Bacon"]
@@ -5141,7 +5141,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       })
 
       // input = String.raw`var name: String = "Joe"
@@ -5335,7 +5335,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`// function body goes here
@@ -5362,7 +5362,7 @@ describe('Parser', function() {
           "body": [],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`/*
@@ -5389,7 +5389,7 @@ describe('Parser', function() {
           "body": [],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -5494,7 +5494,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var diceRoll = 6;
@@ -5597,7 +5597,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var x = true
@@ -5900,7 +5900,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -6029,7 +6029,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var arrays = [[1,2,3], [4,5,6], [7,8,9]]
@@ -6352,7 +6352,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -6504,7 +6504,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var sum = 0
@@ -6535,7 +6535,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",                     value: "EOF"},
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`let interestingNumbers = [
@@ -6648,7 +6648,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",                  value: "EOF"},
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -6742,7 +6742,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var i = 10;
@@ -6830,7 +6830,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var i = 10;
@@ -6924,7 +6924,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`var i = 10
@@ -7014,7 +7014,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -7428,7 +7428,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
 
@@ -7898,7 +7898,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`
@@ -8409,7 +8409,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
   });
@@ -8532,7 +8532,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func someFunction(var a: Int) {
@@ -8650,7 +8650,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func someFunction (var a: Int){
@@ -8691,7 +8691,7 @@ describe('Parser', function() {
           { type: "TERMINATOR",           value: "EOF"}
         ];
         output = "FILL_ME_IN";
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func someFunction(var a: Int){
@@ -8809,7 +8809,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func someFunction        (var a: Int)     {
@@ -8927,7 +8927,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func sayHelloWorld() -> String {
@@ -8993,7 +8993,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func sayHello(var personName: String) -> String {
@@ -9113,7 +9113,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func sayHello(var alreadyGreeted: Bool) -> String {
@@ -9215,7 +9215,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func sayHello(var personName: String, var alreadyGreeted: Bool) -> String {
@@ -9384,7 +9384,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func sayHello(var firstName: String, var lastName: String) -> String {
@@ -9551,7 +9551,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
 
       // input = String.raw`func greet(name: String, day: String) -> String {
@@ -9708,7 +9708,7 @@ describe('Parser', function() {
           ],
           "sourceType": "module"
         };
-        expect(R.equals(parser(input), output)).to.equal(true);
+        expect(isEqual(parser(input), output)).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
This PR uses the individual package [lodash.isequal](https://www.npmjs.com/package/lodash.isequal) for deep equality comparisons. In its next release `lodash.isequal` will be used to power QUnit's `assert.deepEqual` method which is right up the alley for unit testing.
