### PR TITLE
fix an error on `shift.js -r` ?

### DIFF
--- a/command.js
+++ b/command.js
@@ -95,6 +95,7 @@
   // Runs the program.
   var start = function() {
     if (program.run) {
+      var file = program.args.pop();
       if (file.slice(-6) !== '.swift') {
         applyAction(program.args[0]);
       }


### PR DESCRIPTION
``` bash
$ shift.js -r a.swift
/Users/kstg/src/shift-js/command.js:100
      if (file.slice(-6) !== '.swift') {
          ^

ReferenceError: file is not defined
    at start (/Users/kstg/src/shift-js/command.js:100:11)
    at /Users/kstg/src/shift-js/command.js:119:3
    at Object.<anonymous> (/Users/kstg/src/shift-js/command.js:120:3)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```
